### PR TITLE
allow disabling removing from sensu

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![Dependency Status](https://gemnasium.com/badges/github.com/eheydrick/aws-cleaner.svg)](https://gemnasium.com/github.com/eheydrick/aws-cleaner)
 
 AWS Cleaner listens for EC2 termination events produced by AWS [CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html)
-and removes the instances from Chef and Sensu monitoring. Optionally
-sends messages to Hipchat or Slack when actions occur.
+and removes the instances from Chef. It can optionally remove the node from Sensu Monitoring (defaults true), fire off webhooks, and send notifications via Hipchat & Slack when actions occur.
 
 ![aws-cleaner](https://raw.github.com/eheydrick/aws-cleaner/master/aws-cleaner.png)
 
@@ -87,6 +86,23 @@ To enable webhooks, add a `:webhooks:` section to the config:
 
 Chat notifications can be sent when the webhook successfully executes. See
 config.yml.sample for an example of the config.
+
+### Sensu
+
+By default aws-cleaner assumes that removing from sensu is desired as this was one of its core intentions. To allow people to leverage this without sensu you can disable it via config:
+```
+:sensu:
+  :enable: false
+```
+
+When wanting to use sensu you will want the following config:
+```
+:sensu:
+  :url: 'http://sensu.example.com:4567'
+  :enable: true
+```
+
+While we currently assume sensu removal being desired is considered the default it may not always be so you should set `enable` to true to avoid a breaking change later.
 
 ### Limitations
 

--- a/bin/aws_cleaner.rb
+++ b/bin/aws_cleaner.rb
@@ -89,6 +89,7 @@ def chef(id, instance_id, chef_node)
 end
 
 def sensu(id, instance_id, chef_node)
+  return unless @config[:sensu][:enable]
   if AwsCleaner::Sensu.in_sensu?(chef_node, @config)
     if AwsCleaner::Sensu.remove_from_sensu(chef_node, @config)
       @logger.info("Removed #{chef_node} from Sensu")
@@ -113,6 +114,13 @@ end
 @logger = logger(@config)
 @sqs_client = AwsCleaner::SQS.client(@config)
 @chef_client = AwsCleaner::Chef.client(@config)
+
+# to provide backwards compatibility as this key did not exist previously
+@config[:sensu][:enable] = if @config[:sensu][:enable].nil?
+                             true
+                           else
+                             @config[:sensu][:enable]
+                           end
 
 # main loop
 loop do

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -7,6 +7,7 @@
   :queue: 'https://sqs.us-west-2.amazonaws.com/1234/cloudwatch-events'
 :sensu:
   :url: 'http://sensu.example.com:4567'
+  :enable: true
 :chef:
   :url: 'https://chef.example.com/organizations/example'
   :client: 'somebody'


### PR DESCRIPTION
It defaults to the old behavior (not set will equal true) while allowing it to be disabled. At some point in the future we can change that default if that makes sense.

part of but not all of #18 

Signed-off-by: Ben Abrams <me@benabrams.it>